### PR TITLE
M7

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -26,14 +26,15 @@ tasks:
       echo 'loadScript("/workspace/lnsovbridge/etherswap.js")'
       echo 'loadScript("/workspace/lnsovbridge/erc20swap.js")'
       echo 'loadScript("/workspace/lnsovbridge/erc20token.js")'
+      echo 'loadScript("/workspace/lnsovbridge/erc20token.js")'
       geth attach http://127.0.0.1:4444/
     # fund metamask with regtest rsk - rpc url: https://4444-scarlet-kite-mva383vt.ws-us18.gitpod.io, chainid: 33
     # eth.sendTransaction({from:eth.accounts[1], to:'0x946b238f8Ead0170686b32b23070fF4BFB006D3B', value: web3.toWei(10, "ether"), gas:21000}); //fund your wallet
     # eth.sendTransaction({from:eth.accounts[1], to:'0xeCb6b2a431826634E36d2787016670EBd8AF5A9B', value: web3.toWei(10, "ether"), gas:21000}); //fund boltz signer
     # web3.eth.defaultAccount = eth.accounts[1]
     # erc20token.transfer('0x946b238f8Ead0170686b32b23070fF4BFB006D3B', web3.toWei(1000, "ether")); // erc20 tokens to metamask wallet
-    # erc20token.transfer('0xeCb6b2a431826634E36d2787016670EBd8AF5A9B', web3.toWei(1000, "ether")); // erc20 tokens to boltz siger
-    # add erc20 token address to metamask 0x271905cc3d21d8d11f3213e4130108295e578434
+    # erc20token.transfer('0xeCb6b2a431826634E36d2787016670EBd8AF5A9B', web3.toWei(1000, "ether")); // erc20 tokens to boltz signer
+    # add erc20 token address to metamask 0x271905cc3d21d8d11f3213e4130108295e578434 + another time for XUSD 0x738e6fcdd7c1212469da9531a0c7a12aa6e6ccc1
     # geth attach http://127.0.0.1:4444/ --jspath "/workspace/lnsovbridge" --exec 'loadScript("etherswap.js"); loadScript("erc20swap.js");' 
     # sleep 5
     #     web3.eth.defaultAccount = eth.accounts[0]

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -34,7 +34,7 @@ tasks:
     # web3.eth.defaultAccount = eth.accounts[1]
     # erc20token.transfer('0x946b238f8Ead0170686b32b23070fF4BFB006D3B', web3.toWei(1000, "ether")); // erc20 tokens to metamask wallet
     # erc20token.transfer('0xeCb6b2a431826634E36d2787016670EBd8AF5A9B', web3.toWei(1000, "ether")); // erc20 tokens to boltz signer
-    # add erc20 token address to metamask 0x271905cc3d21d8d11f3213e4130108295e578434 + another time for XUSD 0x738e6fcdd7c1212469da9531a0c7a12aa6e6ccc1
+    # add erc20 token address to metamask 0x271905cc3d21d8d11f3213e4130108295e578434 + another time for XUSD 0x738e6fcdd7c1212469da9531a0c7a12aa6e6ccc1 or 0x59014d3017a5ad194d6b8a82a34b5b43beca72f7
     # geth attach http://127.0.0.1:4444/ --jspath "/workspace/lnsovbridge" --exec 'loadScript("etherswap.js"); loadScript("erc20swap.js");' 
     # sleep 5
     #     web3.eth.defaultAccount = eth.accounts[0]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 * LN-SOV Bridge aims to connect SOVRYN and RSK to Lightning Network.  
 * It uses submarine-swaps to enable trustless swaps between RBTC on RSK and Bitcoin on Lightning Network. Swaps are non-custodial and the exchange is KYC-free.
 
-Mainnet version is deployed at: https://lnsov.vercel.app
+Mainnet version is deployed at: https://marduk.exchange
 
 ## install
 * Clone the repo, install requirements and compile  

--- a/boltz.gitpod.conf
+++ b/boltz.gitpod.conf
@@ -41,7 +41,7 @@ port = 9001
 base = "RBTC"
 quote = "BTC"
 rate = 1
-fee = 0.5
+fee = 2
 timeoutDelta = 1_440
 
 [[pairs]]

--- a/boltz.gitpod.conf
+++ b/boltz.gitpod.conf
@@ -1,3 +1,5 @@
+prepayminerfee = true
+
 [api]
 sslEnabled = false
 host = '0.0.0.0'

--- a/boltz.gitpod.conf
+++ b/boltz.gitpod.conf
@@ -50,6 +50,12 @@ quote = "SOV"
 fee = 2
 timeoutDelta = 1_440
 
+[[pairs]]
+base = "BTC"
+quote = "XUSD"
+fee = 2
+timeoutDelta = 1_440
+
 [[currencies]]
 symbol = "BTC"
 network = "bitcoinRegtest"
@@ -145,6 +151,17 @@ erc20SwapAddress = "0x97eee86b78377215230bdf97a7e459e1ff9c63d8"
  decimals = 18
 # gitpod token contract
  contractAddress = "0x271905cc3d21d8d11f3213e4130108295e578434"
+# the actual SOV contract on testnet
+#  contractAddress = "0x6a9a07972d07e58f0daf5122d11e069288a375fb"
+
+ maxSwapAmount = 4_294_96700000
+ minSwapAmount = 10000
+
+ [[rsk.tokens]]
+ symbol = "XUSD"
+ decimals = 18
+# gitpod token contract
+ contractAddress = "0x738e6fcdd7c1212469da9531a0c7a12aa6e6ccc1"
 # the actual SOV contract on testnet
 #  contractAddress = "0x6a9a07972d07e58f0daf5122d11e069288a375fb"
 

--- a/lib/rates/RateCalculator.ts
+++ b/lib/rates/RateCalculator.ts
@@ -12,7 +12,6 @@ class RateCalculator {
     });
 
     let rate = this.aggregator.latestRates.get(pair);
-
     if (rate === undefined) {
       // Try the reverse rate
       rate = this.aggregator.latestRates.get(getPairId({
@@ -30,7 +29,12 @@ class RateCalculator {
           quote: 'BTC',
         }));
 
+        // return rate=1 for RBTC prepayminerfee
+        if (base === 'RBTC' && quote === 'BTC') {
+          return 1;
+        }
         if (baseBtc === undefined) {
+          // console.log('ratecalculator.34');
           throw Errors.COULD_NOT_FIND_RATE(pair);
         }
 
@@ -40,6 +44,7 @@ class RateCalculator {
         }));
 
         if (quoteBtc === undefined) {
+          // console.log('ratecalculator.44');
           throw Errors.COULD_NOT_FIND_RATE(pair);
         }
 

--- a/lib/rates/RateCalculator.ts
+++ b/lib/rates/RateCalculator.ts
@@ -30,11 +30,13 @@ class RateCalculator {
         }));
 
         // return rate=1 for RBTC prepayminerfee
-        if (base === 'RBTC' && quote === 'BTC') {
+        // return some value for SOV as its irrelevant
+        if (base === 'RBTC' || base === 'SOV') {
           return 1;
         }
+        console.log('ratecalc.36 base quote latestrates ', base, quote, this.aggregator.latestRates);
         if (baseBtc === undefined) {
-          // console.log('ratecalculator.34');
+          console.log('ratecalculator.34');
           throw Errors.COULD_NOT_FIND_RATE(pair);
         }
 
@@ -44,7 +46,7 @@ class RateCalculator {
         }));
 
         if (quoteBtc === undefined) {
-          // console.log('ratecalculator.44');
+          console.log('ratecalculator.44');
           throw Errors.COULD_NOT_FIND_RATE(pair);
         }
 

--- a/lib/rates/data/DataAggregator.ts
+++ b/lib/rates/data/DataAggregator.ts
@@ -6,6 +6,7 @@ import Bitfinex from './exchanges/Bitfinex';
 import Poloniex from './exchanges/Poloniex';
 import CoinbasePro from './exchanges/CoinbasePro';
 import Coingecko from './exchanges/Coingecko';
+import Sovryn from './exchanges/Sovryn';
 
 class DataAggregator {
   private readonly exchanges: Exchange[] = [
@@ -15,6 +16,7 @@ class DataAggregator {
     new Poloniex(),
     new CoinbasePro(),
     new Coingecko(),
+    new Sovryn(),
   ];
 
   public readonly pairs = new Set<[string, string]>();

--- a/lib/rates/data/exchanges/Sovryn.ts
+++ b/lib/rates/data/exchanges/Sovryn.ts
@@ -1,0 +1,25 @@
+import Exchange, { makeRequest } from '../Exchange';
+
+class Sovryn implements Exchange {
+  // https://backend.sovryn.app/datafeed/price/RBTC:XUSD?startTime=1640234835000&endTime=1640670495000
+  private static readonly API = 'https://backend.sovryn.app/datafeed/price';
+
+  public async getPrice(baseAsset: string, quoteAsset: string): Promise<number> {
+    // BTC XUSD
+    const startTime = this.getRoundDownTime(10);
+    const response = await makeRequest(`${Sovryn.API}/${baseAsset}:${quoteAsset}?startTime=${startTime}`);
+    // console.log("sovryn response: ", response);
+    const lastprice = response.series[0].close;
+    // console.log("sovryn lastprice: ", lastprice);
+    // return Number(1/lastprice);
+    return Number(lastprice);
+  }
+
+  private getRoundDownTime = (minutes, d=new Date()) => {
+    let ms = 1000 * 60 * minutes; // convert minutes to ms
+    let roundedDate = new Date(Math.floor(d.getTime() / ms) * ms);
+    return roundedDate.getTime()
+  }
+}
+
+export default Sovryn;

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -1013,7 +1013,8 @@ class Service {
 
     const swapIsPrepayMinerFee = this.prepayMinerFee || args.prepayMinerFee === true;
 
-    if (swapIsPrepayMinerFee) {
+    // skip prepayminerfee for ERC20 tokens
+    if (swapIsPrepayMinerFee && sendingCurrency.type !== CurrencyType.ERC20) {
       if (sendingCurrency.type === CurrencyType.BitcoinLike) {
         prepayMinerFeeInvoiceAmount = Math.ceil(baseFee / rate);
         holdInvoiceAmount = Math.floor(holdInvoiceAmount - prepayMinerFeeInvoiceAmount);
@@ -1022,14 +1023,14 @@ class Service {
         prepayMinerFeeOnchainAmount = ethereumPrepayMinerFeeGasLimit.mul(gasPrice).div(etherDecimals).toNumber();
         console.log('service.1022 gasPrice, prepayMinerFeeOnchainAmount ', gasPrice, prepayMinerFeeOnchainAmount);
 
-        // console.log('service.1023 swapIsPrepayMinerFee, sending, receiving ', swapIsPrepayMinerFee, sending, receiving);
+        console.log('service.1023 swapIsPrepayMinerFee, sending, receiving ', swapIsPrepayMinerFee, sending, receiving);
         // const sendingAmountRate = sending === 'ETH' ? 1 : this.rateProvider.rateCalculator.calculateRate('ETH', sending);
         const sendingAmountRate = sending === 'RBTC' ? 1 : this.rateProvider.rateCalculator.calculateRate('RBTC', sending);
 
         // const receivingAmountRate = receiving === 'ETH' ? 1 : this.rateProvider.rateCalculator.calculateRate('ETH', receiving);
         const receivingAmountRate = receiving === 'RBTC' ? 1 : this.rateProvider.rateCalculator.calculateRate('RBTC', receiving);
         prepayMinerFeeInvoiceAmount = Math.ceil(prepayMinerFeeOnchainAmount * receivingAmountRate);
-        console.log('service.1030 prepayMinerFeeOnchainAmount prepayMinerFeeInvoiceAmount receivingAmountRate', prepayMinerFeeOnchainAmount, prepayMinerFeeInvoiceAmount, receivingAmountRate);
+        console.log('service.1030 prepayMinerFeeOnchainAmount prepayMinerFeeInvoiceAmount receivingAmountRate sendingAmountRate', prepayMinerFeeOnchainAmount, prepayMinerFeeInvoiceAmount, receivingAmountRate, sendingAmountRate);
 
         // If the invoice amount was specified, the onchain and hold invoice amounts need to be adjusted
         if (invoiceAmountDefined) {

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -124,7 +124,7 @@ class Service {
 
     const checkCurrency = (symbol: string) => {
       if (!this.currencies.has(symbol)) {
-        // console.log("service.ts line 123");
+        console.log("service.ts line 123 ", );
         throw Errors.CURRENCY_NOT_FOUND(symbol);
       }
     };

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -17,7 +17,8 @@ import { Payment, RouteHint } from '../proto/lnd/rpc_pb';
 import TimeoutDeltaProvider from './TimeoutDeltaProvider';
 import { Network } from '../wallet/ethereum/EthereumManager';
 import RateProvider, { PairType } from '../rates/RateProvider';
-import { getGasPrice } from '../wallet/ethereum/EthereumUtils';
+// import { getGasPrice } from '../wallet/ethereum/EthereumUtils';
+import { getGasPrice } from '../wallet/rsk/EthereumUtils';
 import WalletManager, { Currency } from '../wallet/WalletManager';
 import SwapManager, { ChannelCreationInfo } from '../swap/SwapManager';
 import { etherDecimals, ethereumPrepayMinerFeeGasLimit, gweiDecimals } from '../consts/Consts';
@@ -1019,11 +1020,16 @@ class Service {
       } else {
         const gasPrice = await getGasPrice(sendingCurrency.provider!);
         prepayMinerFeeOnchainAmount = ethereumPrepayMinerFeeGasLimit.mul(gasPrice).div(etherDecimals).toNumber();
+        console.log('service.1022 gasPrice, prepayMinerFeeOnchainAmount ', gasPrice, prepayMinerFeeOnchainAmount);
 
-        const sendingAmountRate = sending === 'ETH' ? 1 : this.rateProvider.rateCalculator.calculateRate('ETH', sending);
+        // console.log('service.1023 swapIsPrepayMinerFee, sending, receiving ', swapIsPrepayMinerFee, sending, receiving);
+        // const sendingAmountRate = sending === 'ETH' ? 1 : this.rateProvider.rateCalculator.calculateRate('ETH', sending);
+        const sendingAmountRate = sending === 'RBTC' ? 1 : this.rateProvider.rateCalculator.calculateRate('RBTC', sending);
 
-        const receivingAmountRate = receiving === 'ETH' ? 1 : this.rateProvider.rateCalculator.calculateRate('ETH', receiving);
+        // const receivingAmountRate = receiving === 'ETH' ? 1 : this.rateProvider.rateCalculator.calculateRate('ETH', receiving);
+        const receivingAmountRate = receiving === 'RBTC' ? 1 : this.rateProvider.rateCalculator.calculateRate('RBTC', receiving);
         prepayMinerFeeInvoiceAmount = Math.ceil(prepayMinerFeeOnchainAmount * receivingAmountRate);
+        console.log('service.1030 prepayMinerFeeOnchainAmount prepayMinerFeeInvoiceAmount receivingAmountRate', prepayMinerFeeOnchainAmount, prepayMinerFeeInvoiceAmount, receivingAmountRate);
 
         // If the invoice amount was specified, the onchain and hold invoice amounts need to be adjusted
         if (invoiceAmountDefined) {

--- a/lib/swap/Errors.ts
+++ b/lib/swap/Errors.ts
@@ -71,4 +71,8 @@ export default {
     message: 'transaction fee is too low',
     code: concatErrorCode(ErrorCodePrefix.Swap, 16),
   }),
+  AMOUNT_TOO_LOW_FOR_CHANNELOPEN: (): Error => ({
+    message: 'amount is too low for channel open',
+    code: concatErrorCode(ErrorCodePrefix.Swap, 17),
+  }),
 };

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -299,9 +299,6 @@ class SwapManager {
     });
 
     if (channelCreation) {
-      // need to decode invoice and throw AMOUNT_TOO_LOW_FOR_CHANNELOPEN
-      // if below a certain amount - to avoid opening small channels
-
       const getChainInfo = async (currency: Currency): Promise<{ blocks: number, blockTime: number }> => {
         if (currency.type === CurrencyType.BitcoinLike) {
           const { blocks } = await currency.chainClient!.getBlockchainInfo();
@@ -346,6 +343,13 @@ class SwapManager {
         } else {
           throw invoiceError;
         }
+      }
+
+      // need to decode invoice and throw AMOUNT_TOO_LOW_FOR_CHANNELOPEN - check after everything else
+      // if below a certain amount - to avoid opening small channels
+      if(decodedInvoice.satoshis < 100000) {
+        console.log('swapmanager.305 decodedInvoice.satoshis is smaller than limit 100k sats ', decodedInvoice.satoshis);
+        throw Errors.AMOUNT_TOO_LOW_FOR_CHANNELOPEN();
       }
 
       await this.channelCreationRepository.setNodePublicKey(channelCreation, decodedInvoice.payeeNodeKey!);

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -530,8 +530,8 @@ class SwapManager {
       refundAddress = refundAddress.toLowerCase();
 
       // HACK: send tokenaddress as redeemScript to frontend so user can claim
-      redeemScript = Buffer.from(this.walletManager.rskManager?.tokenAddresses.get('SOV') || '', 'utf8');
-      this.logger.verbose('swapmanager.225 redeemScript ' + this.walletManager.rskManager?.tokenAddresses.get('SOV') + ', ' + getHexString(redeemScript));
+      redeemScript = Buffer.from(this.walletManager.rskManager?.tokenAddresses.get(args.quoteCurrency) || '', 'utf8');
+      this.logger.verbose('swapmanager.534 redeemScript ' + this.walletManager.rskManager?.tokenAddresses.get(args.quoteCurrency) + ', ' + getHexString(redeemScript));
 
       this.logger.error('prepared reverse swap stuff: ' + blockNumber + ', ' + lockupAddress + ', ' + refundAddress);
 

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -313,7 +313,7 @@ class SwapManager {
         } else {
           return {
             blocks: await currency.provider!.getBlockNumber(),
-            blockTime: TimeoutDeltaProvider.blockTimes.get('ETH')!,
+            blockTime: TimeoutDeltaProvider.blockTimes.get('RBTC')!,
           };
         }
       };
@@ -322,6 +322,7 @@ class SwapManager {
       const blocksUntilExpiry = swap.timeoutBlockHeight - blocks;
 
       const timeoutTimestamp = getUnixTime() + (blocksUntilExpiry * blockTime * 60);
+      console.log('swapmanager.325 channelcreation blocks blockTime blocksUntilExpiry timeoutTimestamp ', blocks, blockTime, blocksUntilExpiry, timeoutTimestamp);
 
       const invoiceError = Errors.INVOICE_EXPIRES_TOO_EARLY(invoiceExpiry, timeoutTimestamp);
 

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -299,6 +299,9 @@ class SwapManager {
     });
 
     if (channelCreation) {
+      // need to decode invoice and throw AMOUNT_TOO_LOW_FOR_CHANNELOPEN
+      // if below a certain amount - to avoid opening small channels
+
       const getChainInfo = async (currency: Currency): Promise<{ blocks: number, blockTime: number }> => {
         if (currency.type === CurrencyType.BitcoinLike) {
           const { blocks } = await currency.chainClient!.getBlockchainInfo();

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -674,7 +674,7 @@ class SwapManager {
     } else if (type === CurrencyType.Rbtc) {
       addresstoreturn = rskManager.etherSwap.address
     } else {
-      if (quoteCurrency == 'SOV') {
+      if (quoteCurrency == 'SOV' || quoteCurrency == 'XUSD') {
         this.logger.error('getlockupcontractaddress from rsk')
         addresstoreturn = rskManager.erc20Swap.address
       } else {

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -221,8 +221,8 @@ class SwapManager {
       claimAddress = await receivingCurrency.wallet.getAddress();
 
       // HACK: send tokenaddress as redeemScript to frontend so user can claim
-      redeemScript = Buffer.from(this.walletManager.rskManager?.tokenAddresses.get('SOV') || '', 'utf8');
-      this.logger.verbose('swapmanager.225 redeemScript ' + getHexString(redeemScript));
+      redeemScript = Buffer.from(this.walletManager.rskManager?.tokenAddresses.get(args.quoteCurrency) || '', 'utf8');
+      this.logger.verbose('swapmanager.225 redeemScript from args.quoteCurrency ' + getHexString(redeemScript!) + ', ' + args.quoteCurrency);
 
       await this.swapRepository.addSwap({
         id,

--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -347,7 +347,8 @@ class SwapManager {
 
       // need to decode invoice and throw AMOUNT_TOO_LOW_FOR_CHANNELOPEN - check after everything else
       // if below a certain amount - to avoid opening small channels
-      if(decodedInvoice.satoshis < 100000) {
+      // TODO: Add another check to see if we already have channels with this peer
+      if(decodedInvoice.satoshis < 100000 && !await this.checkRoutability(sendingCurrency.lndClient!, invoice)) {
         console.log('swapmanager.305 decodedInvoice.satoshis is smaller than limit 100k sats ', decodedInvoice.satoshis);
         throw Errors.AMOUNT_TOO_LOW_FOR_CHANNELOPEN();
       }
@@ -632,7 +633,9 @@ class SwapManager {
         decodedInvoice.numSatoshis;
 
       const routes = await lnd.queryRoutes(decodedInvoice.destination, amountToQuery);
-
+      console.log('swapmanager.636 checkRoutability routes ', routes);
+      // TODO: I think this needs to be simplified - check for amount and if there's an existing channel with node
+      
       // TODO: "routes.routesList.length >= LndClient.paymentParts" when receiver supports MPP?
       return routes.routesList.length > 0;
     } catch (error) {

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -292,19 +292,20 @@ class SwapNursery extends EventEmitter {
 
           case CurrencyType.ERC20:
             this.logger.error("swapnursery reverseswap invoice.paid lockupERC20 for" + quote);
-            if(quote == "SOV") {
+            // if(quote == "SOV" || quote == "XUSD") {
+              // default should be any RSK erc20 token
               await this.rlockupERC20(
                 wallet,
                 lndClient!,
                 reverseSwap,
               );
-            } else {
-              await this.lockupERC20(
-                wallet,
-                lndClient!,
-                reverseSwap,
-              );
-            }
+            // } else {
+            //   await this.lockupERC20(
+            //     wallet,
+            //     lndClient!,
+            //     reverseSwap,
+            //   );
+            // }
 
             break;
         }
@@ -731,53 +732,53 @@ class SwapNursery extends EventEmitter {
     }
   }
 
-  private lockupERC20 = async (
-    wallet: Wallet,
-    lndClient: LndClient,
-    reverseSwap: ReverseSwap,
-  ) => {
-    this.logger.error("swapnursery lockuperc20");
-    try {
-      const walletProvider = wallet.walletProvider as ERC20WalletProvider;
+  // private lockupERC20 = async (
+  //   wallet: Wallet,
+  //   lndClient: LndClient,
+  //   reverseSwap: ReverseSwap,
+  // ) => {
+  //   this.logger.error("swapnursery lockuperc20");
+  //   try {
+  //     const walletProvider = wallet.walletProvider as ERC20WalletProvider;
 
-      let contractTransaction: ContractTransaction;
+  //     let contractTransaction: ContractTransaction;
 
-      if (reverseSwap.minerFeeOnchainAmount) {
-        contractTransaction = await this.walletManager.ethereumManager!.contractHandler.lockupTokenPrepayMinerfee(
-          walletProvider,
-          getHexBuffer(reverseSwap.preimageHash),
-          walletProvider.formatTokenAmount(reverseSwap.onchainAmount),
-          BigNumber.from(reverseSwap.minerFeeOnchainAmount).mul(etherDecimals),
-          reverseSwap.claimAddress!,
-          reverseSwap.timeoutBlockHeight,
-        );
-      } else {
-        this.logger.error("lockuperc20 is called with: walletprovider" + reverseSwap.preimageHash + ", " + walletProvider.formatTokenAmount(reverseSwap.onchainAmount) + ", " + reverseSwap.claimAddress! + ", " + reverseSwap.timeoutBlockHeight);
-        contractTransaction = await this.walletManager.ethereumManager!.contractHandler.lockupToken(
-          walletProvider,
-          getHexBuffer(reverseSwap.preimageHash),
-          walletProvider.formatTokenAmount(reverseSwap.onchainAmount),
-          reverseSwap.claimAddress!,
-          reverseSwap.timeoutBlockHeight,
-        );
-      }
+  //     if (reverseSwap.minerFeeOnchainAmount) {
+  //       contractTransaction = await this.walletManager.ethereumManager!.contractHandler.lockupTokenPrepayMinerfee(
+  //         walletProvider,
+  //         getHexBuffer(reverseSwap.preimageHash),
+  //         walletProvider.formatTokenAmount(reverseSwap.onchainAmount),
+  //         BigNumber.from(reverseSwap.minerFeeOnchainAmount).mul(etherDecimals),
+  //         reverseSwap.claimAddress!,
+  //         reverseSwap.timeoutBlockHeight,
+  //       );
+  //     } else {
+  //       this.logger.error("lockuperc20 is called with: walletprovider " + reverseSwap.preimageHash + ", " + walletProvider.formatTokenAmount(reverseSwap.onchainAmount) + ", " + reverseSwap.claimAddress! + ", " + reverseSwap.timeoutBlockHeight);
+  //       contractTransaction = await this.walletManager.ethereumManager!.contractHandler.lockupToken(
+  //         walletProvider,
+  //         getHexBuffer(reverseSwap.preimageHash),
+  //         walletProvider.formatTokenAmount(reverseSwap.onchainAmount),
+  //         reverseSwap.claimAddress!,
+  //         reverseSwap.timeoutBlockHeight,
+  //       );
+  //     }
 
-      this.ethereumNursery!.listenContractTransaction(reverseSwap, contractTransaction);
-      this.logger.verbose(`Locked up ${reverseSwap.onchainAmount} ${wallet.symbol} for Reverse Swap ${reverseSwap.id}: ${contractTransaction.hash}`);
+  //     this.ethereumNursery!.listenContractTransaction(reverseSwap, contractTransaction);
+  //     this.logger.verbose(`Locked up ${reverseSwap.onchainAmount} ${wallet.symbol} for Reverse Swap ${reverseSwap.id}: ${contractTransaction.hash}`);
 
-      this.emit(
-        'coins.sent',
-        await this.reverseSwapRepository.setLockupTransaction(
-          reverseSwap,
-          contractTransaction.hash,
-          calculateEthereumTransactionFee(contractTransaction),
-        ),
-        contractTransaction.hash,
-      );
-    } catch (error) {
-      await this.handleReverseSwapSendFailed(reverseSwap, wallet.symbol, lndClient, error);
-    }
-  }
+  //     this.emit(
+  //       'coins.sent',
+  //       await this.reverseSwapRepository.setLockupTransaction(
+  //         reverseSwap,
+  //         contractTransaction.hash,
+  //         calculateEthereumTransactionFee(contractTransaction),
+  //       ),
+  //       contractTransaction.hash,
+  //     );
+  //   } catch (error) {
+  //     await this.handleReverseSwapSendFailed(reverseSwap, wallet.symbol, lndClient, error);
+  //   }
+  // }
 
   private rlockupERC20 = async (
     wallet: Wallet,

--- a/lib/swap/SwapNursery.ts
+++ b/lib/swap/SwapNursery.ts
@@ -1169,11 +1169,12 @@ class SwapNursery extends EventEmitter {
 
         case CurrencyType.ERC20:
           this.logger.error("refunderc20 for " + chainSymbol);
-          if(chainSymbol == "SOV") {
+          // make RSK default for refunds
+          // if(chainSymbol == "SOV") {
             await this.rrefundERC20(reverseSwap, chainSymbol);
-          } else {
-            await this.refundERC20(reverseSwap, chainSymbol);
-          }
+          // } else {
+          //   await this.refundERC20(reverseSwap, chainSymbol);
+          // }
           break;
 
         case CurrencyType.Rbtc:
@@ -1258,31 +1259,31 @@ class SwapNursery extends EventEmitter {
     );
   }
 
-  private refundERC20 = async (reverseSwap: ReverseSwap, chainSymbol: string) => {
-    this.logger.error("eth refundERC20");
-    const ethereumManager = this.walletManager.ethereumManager!;
-    const walletProvider = this.walletManager.wallets.get(chainSymbol)!.walletProvider as ERC20WalletProvider;
+  // private refundERC20 = async (reverseSwap: ReverseSwap, chainSymbol: string) => {
+  //   this.logger.error("eth refundERC20");
+  //   const ethereumManager = this.walletManager.ethereumManager!;
+  //   const walletProvider = this.walletManager.wallets.get(chainSymbol)!.walletProvider as ERC20WalletProvider;
 
-    const erc20SwapValues = await queryERC20SwapValuesFromLock(ethereumManager.erc20Swap, reverseSwap.transactionId!);
-    const contractTransaction = await ethereumManager.contractHandler.refundToken(
-      walletProvider,
-      getHexBuffer(reverseSwap.preimageHash),
-      erc20SwapValues.amount,
-      erc20SwapValues.claimAddress,
-      erc20SwapValues.timelock,
-    );
+  //   const erc20SwapValues = await queryERC20SwapValuesFromLock(ethereumManager.erc20Swap, reverseSwap.transactionId!);
+  //   const contractTransaction = await ethereumManager.contractHandler.refundToken(
+  //     walletProvider,
+  //     getHexBuffer(reverseSwap.preimageHash),
+  //     erc20SwapValues.amount,
+  //     erc20SwapValues.claimAddress,
+  //     erc20SwapValues.timelock,
+  //   );
 
-    this.logger.info(`Refunded ${chainSymbol} of Reverse Swap ${reverseSwap.id} in: ${contractTransaction.hash}`);
-    this.emit(
-      'refund',
-      await this.reverseSwapRepository.setTransactionRefunded(
-        reverseSwap,
-        calculateEthereumTransactionFee(contractTransaction),
-        Errors.REFUNDED_COINS(reverseSwap.transactionId!).message,
-      ),
-      contractTransaction.hash,
-    );
-  }
+  //   this.logger.info(`Refunded ${chainSymbol} of Reverse Swap ${reverseSwap.id} in: ${contractTransaction.hash}`);
+  //   this.emit(
+  //     'refund',
+  //     await this.reverseSwapRepository.setTransactionRefunded(
+  //       reverseSwap,
+  //       calculateEthereumTransactionFee(contractTransaction),
+  //       Errors.REFUNDED_COINS(reverseSwap.transactionId!).message,
+  //     ),
+  //     contractTransaction.hash,
+  //   );
+  // }
 
   private rrefundERC20 = async (reverseSwap: ReverseSwap, chainSymbol: string) => {
     this.logger.debug("rsk refundERC20");

--- a/lib/wallet/rsk/EthereumUtils.ts
+++ b/lib/wallet/rsk/EthereumUtils.ts
@@ -22,5 +22,10 @@ export const getGasPrice = async (provider: providers.Provider, gasPrice?: numbe
     return BigNumber.from(gasPrice).mul(gweiDecimals);
   }
 
-  return getBiggerBigNumber(await provider.getGasPrice(), GasNow.latestGasPrice);
+  // for rsk mainnet tx uses 0.000000000065164 gas which is returned as {"jsonrpc":"2.0","id":73,"result":"0x3e252e0"} = 65164000
+  // from {"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":73}
+  // on mainnet this already returns 65164000 so not changing it
+  console.log('rsk/utils.26 getGasPrice getBiggerBigNumber: ', await provider.getGasPrice(), GasNow.latestGasPrice, BigNumber.from(65164000))
+  // GasNow.latestGasPrice, -> doesn't exist and doesn't make sense for rsk anyway
+  return getBiggerBigNumber(await provider.getGasPrice(), BigNumber.from(65164000));
 };

--- a/lib/wallet/rsk/EthereumUtils.ts
+++ b/lib/wallet/rsk/EthereumUtils.ts
@@ -22,7 +22,7 @@ export const getGasPrice = async (provider: providers.Provider, gasPrice?: numbe
     return BigNumber.from(gasPrice).mul(gweiDecimals);
   }
 
-  // for rsk mainnet tx uses 0.000000000065164 gas which is returned as {"jsonrpc":"2.0","id":73,"result":"0x3e252e0"} = 65164000
+  // for rsk mainnet tx uses 0.000000000065164 RBTC gas which is returned as {"jsonrpc":"2.0","id":73,"result":"0x3e252e0"} = 65164000wei=0.065164gwei=651sats
   // from {"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":73}
   // on mainnet this already returns 65164000 so not changing it
   console.log('rsk/utils.26 getGasPrice getBiggerBigNumber: ', await provider.getGasPrice(), GasNow.latestGasPrice, BigNumber.from(65164000))


### PR DESCRIPTION
This PR adds following functionality as part of milestone-7:

prepayminerfee feature
- When user wants to go offchain -> onchain (reverse submarine swap) they need initial funds in their wallet to do a `claim` contract call to get funds locked in the swap contract.
- This feature introduces (only for pair LNBTC -> RBTC) an additional `custodial` invoice during reverse swaps such that when both invoices are paid and backend locks funds to the contract, minerfeeinvoice equivalent funds are transferred to the user's claim address.

open a channel if no routes
- This introduces a new feature when during regular swaps, backend calculates routes to pay the invoice and if no routes are found *and* backend has onchain funds, it will open a channel 2x the size of the swap to the user's node.

add xusd 
- Adds swaps for BTC/XUSD pair with sovryn as pricefeed and integrated into the dataaggregator.
